### PR TITLE
Release fix of nuLiga Calls

### DIFF
--- a/release.sql
+++ b/release.sql
@@ -1,3 +1,0 @@
-ALTER TABLE club_meeting add COLUMN team_id bigint;
-ALTER TABLE club_meeting add COLUMN courtHallName varchar;
-ALTER TABLE club_meeting ADD CONSTRAINT fk_clubmeeting_team_id FOREIGN KEY (team_id) REFERENCES team(id);

--- a/src/main/java/de/altenerding/biber/pinkie/business/nuLiga/control/NuLigaApiRequester.java
+++ b/src/main/java/de/altenerding/biber/pinkie/business/nuLiga/control/NuLigaApiRequester.java
@@ -48,16 +48,20 @@ public class NuLigaApiRequester {
         }
     }
 
-    public GroupTableDTO getTeamTable(String nuLigaTeamId) {
+    public GroupTableDTO getTeamTable(String nuLigaTeamId, String nuLigaGroupId) {
         NuLigaApi nuLigaApi = retrofit.create(NuLigaApi.class);
         Call<TeamGroupTablesDTO> call = nuLigaApi.getTeamGroupTables(nuLigaTeamId);
         TeamGroupTablesDTO teamGroupTablesDTO = retrofitRequester.executeSyncronousCall(call);
 
         if (teamGroupTablesDTO != null) {
-            return teamGroupTablesDTO.getGroupTables().get(0);
-        } else {
-            return null;
+            for (GroupTableDTO groupTableDTO : teamGroupTablesDTO.getGroupTables()) {
+                if (groupTableDTO.getGroupId().equals(nuLigaGroupId)) {
+                    return groupTableDTO;
+                }
+            }
         }
+
+        return null;
     }
 
     public List<MeetingAbbrDTO> getClubMeetingsOfCurrentSeason() {

--- a/src/main/java/de/altenerding/biber/pinkie/business/nuLiga/control/NuLigaDataProcessor.java
+++ b/src/main/java/de/altenerding/biber/pinkie/business/nuLiga/control/NuLigaDataProcessor.java
@@ -37,7 +37,7 @@ public class NuLigaDataProcessor {
                 logger.warn("No nuLiga team id provided for {} with id={}", team.getName(), team.getId());
             } else {
                 logger.info("Loading nuLiga table for {} with id={}", team.getName(), team.getId());
-                GroupTableDTO groupTableDTO = nuLigaApiRequester.getTeamTable(team.getNuLigaTeamId());
+                GroupTableDTO groupTableDTO = nuLigaApiRequester.getTeamTable(team.getNuLigaTeamId(), team.getNuLigaGroupId());
                 List<GroupTableTeam> from = GroupTableTeamDTOMapper.from(groupTableDTO);
                 logger.info("Found {} entries for ranking table of team with id={}", from.size(), team.getId());
                 for (GroupTableTeam groupTableTeam : from) {

--- a/src/main/java/de/altenerding/biber/pinkie/presentation/team/TeamEditBean.java
+++ b/src/main/java/de/altenerding/biber/pinkie/presentation/team/TeamEditBean.java
@@ -71,7 +71,7 @@ public class TeamEditBean implements Serializable {
 
 		List<TeamAbbrDTO> teamAbbrDTO = nuLigaBean.getTeamAbbrDTO();
 		for (TeamAbbrDTO abbrDTO : teamAbbrDTO) {
-			if (abbrDTO.getTeamId().equals(team.getNuLigaTeamId())) {
+			if (abbrDTO.getGroupId().equals(team.getNuLigaGroupId())) {
 				selectedNuLigaTeam = abbrDTO;
 			}
 		}


### PR DESCRIPTION
Es gab ein Problem bei der Anzeige der Teams mit dem Dropdown für die Mannschaft. Da es z.B. bei der mD für die Vorrunde und Rückrunde verschiedene Gruppen gibt, muss diese zum Wechsel geändert werden. Dies hatte nicht funktioniert, da hardcoded immer das erste Element in der List genommen wurde.